### PR TITLE
Set build-server base image to golang 1.17.8 to avoid crash-loops

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN cd /go/src/ && git clone https://github.com/orzhaha/cassandra-web.git
 RUN cd /go/src/cassandra-web/client && npm i && npm run build
 
 # build server stage
-FROM golang:1.17.8-alpine AS build-server-env
+FROM golang:1.17.9-alpine AS build-server-env
 
 RUN apk add --no-cache git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN cd /go/src/ && git clone https://github.com/orzhaha/cassandra-web.git
 RUN cd /go/src/cassandra-web/client && npm i && npm run build
 
 # build server stage
-FROM golang:1.18-alpine AS build-server-env
+FROM golang:1.17.8-alpine AS build-server-env
 
 RUN apk add --no-cache git
 

--- a/kubernetes/helm/cassandra-web/templates/deployment.yaml
+++ b/kubernetes/helm/cassandra-web/templates/deployment.yaml
@@ -27,14 +27,14 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
           - name: HOST_PORT
-            value: ":{{ .Values.service.port }}"
+            value: ":{{ .Values.service.targetPort }}"
           - name: CASSANDRA_HOST
             value: {{ .Values.db.host }}
           - name: CASSANDRA_PORT
             value: "{{ .Values.db.port }}"
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/kubernetes/helm/cassandra-web/templates/ingress.yaml
+++ b/kubernetes/helm/cassandra-web/templates/ingress.yaml
@@ -33,6 +33,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
+            pathType: {{ .pathType }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}

--- a/kubernetes/helm/cassandra-web/templates/service.yaml
+++ b/kubernetes/helm/cassandra-web/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: http
   selector:

--- a/kubernetes/helm/cassandra-web/values.yaml
+++ b/kubernetes/helm/cassandra-web/values.yaml
@@ -17,15 +17,18 @@ image:
 service:
   type: ClusterIP
   port: 80
+  targetPort: 8080
 
 ingress:
   enabled: false
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  path: /
   hosts:
-    - chart-example.local
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: Prefix
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
Will probably want to bump this back up to 1.17.9 when it comes out later this week, but the app won't serve users using 1.18 as a base image. 1.18-alpine will run the app, but the app can't serve users with it, as it returns 500 errors trying to load /readonly, before settling into a crashloop pattern.