### PR TITLE
fix: update deprecated apiVersion and path entries

### DIFF
--- a/kubernetes/helm/cassandra-web/templates/ingress.yaml
+++ b/kubernetes/helm/cassandra-web/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cassandra-web.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -35,8 +31,10 @@ spec:
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
The ingress of this chart is not working with modern k8s versions.
`networking.k8s.io/v1beta1` was [removed since 1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122), which has been EOL since 2023.